### PR TITLE
decode float using uint64

### DIFF
--- a/bson/decode.lisp
+++ b/bson/decode.lisp
@@ -47,9 +47,17 @@
         (1- (- (logandc2 #xFFFFFFFFFFFFFFFF ui64)))
         ui64)))
 
+(defun decode-uint64 (source)
+  "Decode 64-bit unsigned integer from SOURCE"
+  (let ((ui64 0))
+    (iter (for i from 0 below 64 by 8)
+          (setf (ldb (byte 8 i) ui64)
+                (decode-byte source)))
+    ui64))
+
 (defun decode-double (source)
   "Decode 64-bit IEEE 754 floating point from SOURCE"
-  (ieee-floats:decode-float64 (decode-int64 source)))
+  (ieee-floats:decode-float64 (decode-uint64 source)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Non-terminals


### PR DESCRIPTION
@archimag  `ieee-floats:decode-float` expects an `(unsigned-byte 64)`, however it was being supplied with a `signed-byte` and will cause the bson decoding to fail for floating point numbers where the most significant bit is 1.  

This patch resolves this issue by passing in an `unsigned-byte` instead.
